### PR TITLE
fix how to hadd file for qcd smearing

### DIFF
--- a/python/processors/Stop0l_postproc_QCD.py
+++ b/python/processors/Stop0l_postproc_QCD.py
@@ -29,7 +29,7 @@ def main(args):
     for line in lines:
         files.append(line.strip())
 
-    p=PostProcessor(args.outputfile,files,cut=None, branchsel=None, haddFileName=True,outputbranchsel="keep_and_drop_QCD.txt", outputbranchselsmear="keep_and_drop_smear.txt",typeofprocess="smear",modules=mods,provenance=False)
+    p=PostProcessor(args.outputfile,files,cut=None, branchsel=None, outputbranchsel="keep_and_drop_QCD.txt", outputbranchselsmear="keep_and_drop_smear.txt",typeofprocess="smear",modules=mods,provenance=False)
     p.run()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Not using hadd file in postprocess. Using RunExe.csh hadd method