### PR TITLE
Condor spliting base on real number of events

### DIFF
--- a/python/modules/Stop0lObjectsProducer.py
+++ b/python/modules/Stop0lObjectsProducer.py
@@ -116,9 +116,9 @@ class Stop0lObjectsProducer(Module):
 
     def SelBtagJets(self, jet):
         global DeepCSVMediumWP
-        if jet.btagDeepB < DeepCSVMediumWP[self.era]:
-            return False
-        return True
+        if jet.btagDeepB >= DeepCSVMediumWP[self.era]:
+            return True
+        return False
 
     def SelSoftb(self, isv):
         ## Select soft bs

--- a/python/processors/Condor/SubmitLPC.py
+++ b/python/processors/Condor/SubmitLPC.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 DelExe    = '../Stop0l_postproc.py'
 tempdir = '/uscms_data/d3/%s/condor_temp/' % getpass.getuser()
 ShortProjectName = 'PostProcess'
-VersionNumber = '_v2p8'
+VersionNumber = '_v2p7'
 argument = "--inputFiles=%s.$(Process).list "
 sendfiles = ["../keep_and_drop.txt"]
 TTreeName = "Events"


### PR DESCRIPTION
Using uproot to read fEntries of the tree, which is 20 times
faster than default ROOT.GetEntries()

Now the submission will take a while, as for large filelist. But
hopefully this will fix the tail of the running time on condor and
prevent jobs got killed