### PR TITLE
Remove PassJetID from PassEventFilter

### DIFF
--- a/python/modules/Stop0lBaselineProducer.py
+++ b/python/modules/Stop0lBaselineProducer.py
@@ -197,7 +197,7 @@ class Stop0lBaselineProducer(Module):
         ## This was an old recommendation in ICHEP16, store this optional bit in case we need it
         ## https://twiki.cern.ch/twiki/bin/viewauth/CMS/SUSRecommendationsICHEP16 
         PassCaloMETRatio= (met.pt / caloMET.pt ) < 5 if caloMET.pt > 0 else True
-        PassEventFilter = self.PassEventFilter(flags) and PassJetID
+        PassEventFilter = self.PassEventFilter(flags)
 
         countEle, countMu, countIsk = self.calculateNLeptons(electrons, muons, isotracks)
         PassElecVeto    = countEle == 0
@@ -219,16 +219,16 @@ class Stop0lBaselineProducer(Module):
         PassdPhiHighDM  = self.PassdPhi(sortedPhi, [0.5, 0.5, 0.5, 0.5])
         PassdPhiQCD     = self.PassdPhi(sortedPhi, [0.1, 0.1, 0.1], invertdPhi =True)
 
-        PassBaseline    = PassEventFilter and PassLeptonVeto and PassNjets and PassMET and PassHT and PassdPhiLowDM
+        PassBaseline    = PassEventFilter and PassJetID and PassLeptonVeto and PassNjets and PassMET and PassHT and PassdPhiLowDM
         PasshighDM      = PassBaseline and stop0l.nJets >= 5 and PassdPhiHighDM and stop0l.nbtags >= 1
         PasslowDM       = PassBaseline and stop0l.nTop == 0 and stop0l.nW == 0 and stop0l.nResolved == 0 and \
                 stop0l.Mtb < 175 and stop0l.ISRJetPt > 200 and stop0l.METSig > 10
-        PassQCDCR       = PassEventFilter and PassLeptonVeto and PassNjets and PassMET and PassHT and PassdPhiQCD
+        PassQCDCR       = PassEventFilter and PassJetID and PassLeptonVeto and PassNjets and PassMET and PassHT and PassdPhiQCD
         PassQCD_highDM  = PassQCDCR and stop0l.nJets >= 5 and stop0l.nbtags >= 1
         PassQCD_lowDM   = PassQCDCR and stop0l.nTop == 0 and stop0l.nW == 0 and stop0l.nResolved == 0 and \
                 stop0l.Mtb < 175 and stop0l.ISRJetPt > 200 and stop0l.METSig > 10
 
-        PassLLCR       = PassEventFilter and PassLLLep and PassNjets and PassMET and PassHT and PassdPhiLowDM
+        PassLLCR       = PassEventFilter and PassJetID and PassLLLep and PassNjets and PassMET and PassHT and PassdPhiLowDM
         PassLL_highDM  = PassLLCR and stop0l.nJets >= 5 and PassdPhiHighDM and stop0l.nbtags >= 1
         PassLL_lowDM   = PassLLCR and stop0l.nTop == 0 and stop0l.nW == 0 and stop0l.nResolved == 0 and \
                 stop0l.Mtb < 175 and stop0l.ISRJetPt > 200 and stop0l.METSig > 10


### PR DESCRIPTION
Remove PassJetID from PassEventFilter due to issues in photon control region with JetID.

Here is the results of testing this PR (print statement only for testing, not in PR).

## QCD MC (2016)
```
python Stop0l_postproc.py -i file:root://cmseos.fnal.gov//eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Feb2019/QCD_HT100to200_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/2016_MINIAODv3_RunIISummer16MiniAODv3-PUMoriond17_94X_v3-v1/190225_211123/0000/prod2016MC_NANO_1.root -e 2016 -m 500

PassJetID: True PassEventFilter: True
PassJetID: True PassEventFilter: True
PassJetID: True PassEventFilter: True
PassJetID: True PassEventFilter: True
PassJetID: True PassEventFilter: True
PassJetID: False PassEventFilter: True
PassJetID: False PassEventFilter: True
PassJetID: False PassEventFilter: True
PassJetID: False PassEventFilter: True
PassJetID: False PassEventFilter: True
```

![jetid_eventfilter_mc](https://user-images.githubusercontent.com/19024727/61910170-7d130900-aef9-11e9-842a-6b77934fd3f8.png)

## Single Photon Data (2016)
```
python Stop0l_postproc.py -i file:root://cmseos.fnal.gov//store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_10Feb2019/SinglePhoton/2016_Data_Run2016B-17Jul2018_ver2-v1/190211_053725/0000/prod2016Data_NANO_1-1.root -e 2016 -d B -m 500

PassJetID: True PassEventFilter: True
PassJetID: False PassEventFilter: True
PassJetID: True PassEventFilter: True
PassJetID: True PassEventFilter: True
PassJetID: False PassEventFilter: True
PassJetID: False PassEventFilter: True
PassJetID: True PassEventFilter: True
PassJetID: True PassEventFilter: True
```

![jetid_eventfilter_data](https://user-images.githubusercontent.com/19024727/61910192-89976180-aef9-11e9-82e2-af67e1b82e40.png)


