### PR TITLE
Fix photon pt cut, eta cut, and ID

### DIFF
--- a/python/modules/Stop0lObjectsProducer.py
+++ b/python/modules/Stop0lObjectsProducer.py
@@ -133,21 +133,23 @@ class Stop0lObjectsProducer(Module):
 
 
     def SelJets(self, jet):
-        if jet.pt < 20 or math.fabs(jet.eta) > 2.4 :
+        if jet.pt < 20 or math.fabs(jet.eta) > 2.4:
             return False
         return True
 
     def SelPhotons(self, photon):
-        if photon.pt < 200:
+        if photon.pt < 220:
             return False
         abeta = math.fabs(photon.eta)
-        if (abeta > 1.442 and abeta < 1.566) or (abeta > 2.5):
+        if (abeta > 1.4442 and abeta < 1.566) or (abeta > 2.5):
             return False
-        ## cut-base ID, 2^0 loose ID
-        cutbase =  photon.cutBasedBitmap  if self.era != "2016" else photon.cutBased
-        if not cutbase & 0b1:
-            return False
-        return True
+        # --- Photon ID: cut-based medium ID --- #
+        # 2016:      Use Photon_cutBased       : Int_t cut-based Spring16-V2p2 ID (0:fail, 1: :loose, 2:medium, 3:tight)
+        # 2017,2018: Use Photon_cutBasedBitmap : Int_t cut-based ID bitmap, 2^(0:loose, 1: medium, 2:tight); should be 2017 V2
+        if self.era == "2016":
+            return bool(photon.cutBased > 1) 
+        else:
+            return bool(photon.cutBasedBitmap & 2) 
 
     def CalHT(self, jets):
         HT = sum([j.pt for i, j in enumerate(jets) if self.Jet_Stop0l[i]])

--- a/python/modules/Stop0lObjectsProducer.py
+++ b/python/modules/Stop0lObjectsProducer.py
@@ -138,12 +138,15 @@ class Stop0lObjectsProducer(Module):
         return True
 
     def SelPhotons(self, photon):
+        # CMSSW Reference for eta cuts: https://github.com/cms-sw/cmssw/blob/02d4198c0b6615287fd88e9a8ff650aea994412e/DQM/Physics/python/singleTopDQM_miniAOD_cfi.py#L47
         abeta = math.fabs(photon.eta)
-        if (abeta > 1.4442 and abeta < 1.566) or (abeta > 2.5):
+        if (abeta > 1.4442 and abeta < 1.5660) or (abeta > 2.5):
             return False
-        # --- Photon ID: cut-based medium ID --- #
+        # Photon ID MC 102X (for 2017/2018) Reference: https://cms-nanoaod-integration.web.cern.ch/integration/master-102X/mc102X_doc.html#Photon
+        # --- Photon ID: cut-based medium ID from NanoAOD --- #
         # 2016:      Use Photon_cutBased       : Int_t cut-based Spring16-V2p2 ID (0:fail, 1: :loose, 2:medium, 3:tight)
         # 2017,2018: Use Photon_cutBasedBitmap : Int_t cut-based ID bitmap, 2^(0:loose, 1: medium, 2:tight); should be 2017 V2
+        # Using medium photon ID
         if self.era == "2016":
             return bool(photon.cutBased > 1) 
         else:

--- a/python/modules/Stop0lObjectsProducer.py
+++ b/python/modules/Stop0lObjectsProducer.py
@@ -138,8 +138,6 @@ class Stop0lObjectsProducer(Module):
         return True
 
     def SelPhotons(self, photon):
-        if photon.pt < 220:
-            return False
         abeta = math.fabs(photon.eta)
         if (abeta > 1.4442 and abeta < 1.566) or (abeta > 2.5):
             return False


### PR DESCRIPTION
I have fixed the photon pt cut, eta cut, and ID
* pt cut: 
```photon.pt < 220```
* eta cut: 
```(abeta > 1.4442 and abeta < 1.566) or (abeta > 2.5)```
* medium ID:
```
bool(photon.cutBased > 1) for 2016
bool(photon.cutBasedBitmap & 2) for 2017,2018
```

# Testing
* print statement for testing
```
        # testing photons
        for i, photon in enumerate(photons):
            if self.era == "2016":
                print "Photon {0}: pt={1} eta={2} id={3} Photon_Stop0l={4}".format(i, photon.pt, photon.eta, photon.cutBased, self.Photon_Stop0l[i])
            else:
                print "Photon {0}: pt={1} eta={2} id={3} Photon_Stop0l={4}".format(i, photon.pt, photon.eta, photon.cutBasedBitmap, self.Photon_Stop0l[i])
```

* example output for GJets MC

## 2016
```
python Stop0l_postproc.py -i file:root://cmseos.fnal.gov//eos/uscms/store/user/lpcsusyhad/Stop_production/Summer16_94X_v3/PreProcessed_22Feb2019/GJets_DR-0p4_HT-600ToInf_TuneCUETP8M1_13TeV-madgraphMLM-pythia8/2016_MINIAODv3_RunIISummer16MiniAODv3-PUMoriond17_qcut19_94X_v3-v2/190225_155158/0000/prod2016MC_NANO_1-1.root -e 2016 -m 500

Photon 1: pt=229.297851562 eta=1.12451171875 id=3 Photon_Stop0l=True
Photon 2: pt=13.7236471176 eta=1.28930664062 id=1 Photon_Stop0l=False
Photon 0: pt=345.076019287 eta=0.838623046875 id=0 Photon_Stop0l=False
Photon 1: pt=229.297851562 eta=1.12451171875 id=3 Photon_Stop0l=True
Photon 2: pt=13.7236471176 eta=1.28930664062 id=1 Photon_Stop0l=False
Photon 0: pt=345.076019287 eta=0.838623046875 id=0 Photon_Stop0l=False
Photon 1: pt=229.297851562 eta=1.12451171875 id=3 Photon_Stop0l=True
Photon 2: pt=13.7236471176 eta=1.28930664062 id=1 Photon_Stop0l=False
Photon 0: pt=345.076019287 eta=0.838623046875 id=0 Photon_Stop0l=False
Photon 1: pt=229.297851562 eta=1.12451171875 id=3 Photon_Stop0l=True
Photon 2: pt=13.7236471176 eta=1.28930664062 id=1 Photon_Stop0l=False
Photon 0: pt=345.076019287 eta=0.838623046875 id=0 Photon_Stop0l=False
Photon 1: pt=229.297851562 eta=1.12451171875 id=3 Photon_Stop0l=True
Photon 2: pt=13.7236471176 eta=1.28930664062 id=1 Photon_Stop0l=False
Photon 0: pt=256.830505371 eta=-0.710205078125 id=0 Photon_Stop0l=False
```
![test_photonID_2016](https://user-images.githubusercontent.com/19024727/62310665-9f53dc00-b44f-11e9-9200-f254f06da691.png)

## 2017
```
python Stop0l_postproc.py -i file:root://cmseos.fnal.gov//eos/uscms/store/user/lpcsusyhad/Stop_production/Fall17_94X_v2_NanAOD_MC/PreProcessed_15Jan2019/GJets_DR-0p4_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/2017_MC_RunIIFall17MiniAODv2-PU2017_12Apr2018_94X_v14-v2/190111_050337/0000/prod2017MC_NANO_1-1.root -e 2017 -m 500

Photon 0: pt=114.79737854 eta=-1.36840820312 id=7 Photon_Stop0l=False
Photon 0: pt=114.79737854 eta=-1.36840820312 id=7 Photon_Stop0l=False
Photon 0: pt=114.79737854 eta=-1.36840820312 id=7 Photon_Stop0l=False
Photon 0: pt=114.79737854 eta=-1.36840820312 id=7 Photon_Stop0l=False
Photon 0: pt=114.79737854 eta=-1.36840820312 id=7 Photon_Stop0l=False
Photon 0: pt=544.705200195 eta=-1.33471679688 id=3 Photon_Stop0l=True
Photon 0: pt=544.705200195 eta=-1.33471679688 id=3 Photon_Stop0l=True
Photon 0: pt=544.705200195 eta=-1.33471679688 id=3 Photon_Stop0l=True
Photon 0: pt=544.705200195 eta=-1.33471679688 id=3 Photon_Stop0l=True
Photon 0: pt=544.705200195 eta=-1.33471679688 id=3 Photon_Stop0l=True
```
![test_photonID_2017](https://user-images.githubusercontent.com/19024727/62310678-a7138080-b44f-11e9-9430-ccaa48629c84.png)

## 2018
```
python Stop0l_postproc.py -i file:root://cmseos.fnal.gov//eos/uscms/store/user/lpcsusyhad/Stop_production/Autumn18_102X_v1/PreProcessed_22March2019/GJets_DR-0p4_HT-600ToInf_TuneCP5_13TeV-madgraphMLM-pythia8/2018_Data_RunIIAutumn18MiniAOD-102X_v15-v1/190329_050739/0000/prod2018MC_NANO_1-1.root -e 2018 -m 500

Photon 0: pt=291.863800049 eta=-1.81713867188 id=7 Photon_Stop0l=True
Photon 1: pt=36.852230072 eta=-1.28564453125 id=0 Photon_Stop0l=False
Photon 2: pt=16.3024082184 eta=-1.31494140625 id=0 Photon_Stop0l=False
Photon 3: pt=16.1418457031 eta=0.66064453125 id=0 Photon_Stop0l=False
Photon 0: pt=291.863800049 eta=-1.81713867188 id=7 Photon_Stop0l=True
Photon 1: pt=36.852230072 eta=-1.28564453125 id=0 Photon_Stop0l=False
Photon 2: pt=16.3024082184 eta=-1.31494140625 id=0 Photon_Stop0l=False
Photon 3: pt=16.1418457031 eta=0.66064453125 id=0 Photon_Stop0l=False
Photon 0: pt=291.863800049 eta=-1.81713867188 id=7 Photon_Stop0l=True
Photon 1: pt=36.852230072 eta=-1.28564453125 id=0 Photon_Stop0l=False
Photon 2: pt=16.3024082184 eta=-1.31494140625 id=0 Photon_Stop0l=False
Photon 3: pt=16.1418457031 eta=0.66064453125 id=0 Photon_Stop0l=False
Photon 0: pt=291.863800049 eta=-1.81713867188 id=7 Photon_Stop0l=True
Photon 1: pt=36.852230072 eta=-1.28564453125 id=0 Photon_Stop0l=False
Photon 2: pt=16.3024082184 eta=-1.31494140625 id=0 Photon_Stop0l=False
Photon 3: pt=16.1418457031 eta=0.66064453125 id=0 Photon_Stop0l=False
Photon 0: pt=291.863800049 eta=-1.81713867188 id=7 Photon_Stop0l=True
Photon 1: pt=36.852230072 eta=-1.28564453125 id=0 Photon_Stop0l=False
Photon 2: pt=16.3024082184 eta=-1.31494140625 id=0 Photon_Stop0l=False
Photon 3: pt=16.1418457031 eta=0.66064453125 id=0 Photon_Stop0l=False
```
![test_photonID_2018](https://user-images.githubusercontent.com/19024727/62310692-ada1f800-b44f-11e9-87a1-1d1f10016f69.png)
