### PR TITLE
Add files for preprocessed fastsim splitting

### DIFF
--- a/python/processors/Condor/RunExe_fastsim.csh
+++ b/python/processors/Condor/RunExe_fastsim.csh
@@ -1,0 +1,64 @@
+#!/bin/csh -v
+
+set SCRAM  = DELSCR
+set CMSSW  = DELDIR
+set EXE    = DELEXE
+set OUTPUT = OUTDIR
+
+#============================================================================#
+#-----------------------------   Setup the env   ----------------------------#
+#============================================================================#
+echo "============  Running on" $HOST " ============"
+cd ${_CONDOR_SCRATCH_DIR}
+source /cvmfs/cms.cern.ch/cmsset_default.csh
+setenv SCRAM_ARCH ${SCRAM}
+eval `scramv1 project CMSSW ${CMSSW}`
+tar -xzf ${_CONDOR_SCRATCH_DIR}/CMSSW.tar.gz
+cd ${CMSSW}
+eval `scramv1 runtime -csh` # cmsenv is an alias not on the workers
+echo "CMSSW: "$CMSSW_BASE
+
+cd ${_CONDOR_SCRATCH_DIR}
+foreach tarfile (`ls *gz FileList/*gz`)
+  echo $tarfile
+  tar -xzf $tarfile 
+end
+
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Setup for rootpy ~~~~~
+setenv PYTHONPATH  ${_CONDOR_SCRATCH_DIR}
+setenv XDG_CONFIG_HOME ${_CONDOR_SCRATCH_DIR}/.config
+setenv XDG_CACHE_HOME ${_CONDOR_SCRATCH_DIR}/.cache
+
+if ! $?LD_LIBRARY_PATH then
+    setenv LD_LIBRARY_PATH ./
+else
+    setenv LD_LIBRARY_PATH ./:${LD_LIBRARY_PATH}
+endif
+
+#============================================================================#
+#--------------------------   To Run the Process   --------------------------#
+#============================================================================#
+
+#argv[1] is the hadd file name that will be copied over. Other arguments are for the postprocessor.
+echo $EXE $argv[2-]
+python $EXE $argv[2-]
+
+if ($? == 0) then
+  #echo "Process finished. Listing current files: "
+  echo "Process finished. Removing (unmerged) Skim files."
+  #echo "Hadd file will be named: " $argv[1]
+  foreach outfile (`ls *_Skim*.root`)
+    rm $outfile
+  end
+
+  foreach outfile (`ls *_Mom*_LSP*.root`)
+    #Cut off ".root" and append "_{ProcessNum}.root", passed as first argument
+    set cutoffoutfile = `echo $outfile | rev | cut -c 6- | rev`
+    echo "Copying " $outfile " to root://cmseos.fnal.gov/${OUTPUT}/$cutoffoutfile$argv[1]"
+    xrdcp -f $outfile "root://cmseos.fnal.gov/${OUTPUT}/$cutoffoutfile$argv[1]"
+    ## Remove output file once it is copied
+    if ($? == 0) then
+      rm $outfile
+    endif
+  end
+endif

--- a/python/processors/Condor/SubmitLPC_fast.py
+++ b/python/processors/Condor/SubmitLPC_fast.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python
+# coding: utf-8
+
+from __future__ import division
+import os
+import re
+import time
+import subprocess
+import glob
+import tarfile
+import shutil
+import getpass
+import math
+import argparse
+import uproot
+from collections import defaultdict
+from multiprocessing import Pool
+from itertools import izip_longest
+
+# DelExe    = '../Stop0l_splitHEM.py'
+DelExe    = '../Stop0l_fastsim.py'
+tempdir = "/uscmst1b_scratch/lpc1/3DayLifetime/ahenckel/TestCondor/"
+ShortProjectName = 'PreProcess17'
+# VersionNumber = '_splitHEM'
+VersionNumber = '_fastsimv4'
+argument = "--inputFiles=%s.$(Process).list "
+sendfiles = ["/uscms/home/benwu/python-packages.tgz", "../keep_and_drop.txt"]
+TTreeName = "Events"
+NProcess = 10
+
+def tar_cmssw():
+    print("Tarring up CMSSW, ignoring file larger than 100MB")
+    cmsswdir = os.environ['CMSSW_BASE']
+    cmsswtar = os.path.abspath('%s/CMSSW.tar.gz' % tempdir)
+    if os.path.exists(cmsswtar):
+        ans = raw_input('CMSSW tarball %s already exists, remove? [yn] ' % cmsswtar)
+        if ans.lower()[0] == 'y':
+            os.remove(cmsswtar)
+        else:
+            return
+
+    def exclude(tarinfo):
+        if tarinfo.size > 100*1024*1024:
+            tarinfo = None
+            return tarinfo
+        exclude_patterns = ['/.git/', '/tmp/', '/jobs.*/', '/logs/', '/.SCRAM/', '.pyc']
+        for pattern in exclude_patterns:
+            if re.search(pattern, tarinfo.name):
+                # print('ignoring %s in the tarball', tarinfo.name)
+                tarinfo = None
+                break
+        return tarinfo
+
+    with tarfile.open(cmsswtar, "w:gz",dereference=True) as tar:
+        tar.add(cmsswdir, arcname=os.path.basename(cmsswdir), filter=exclude)
+    return cmsswtar
+
+def ConfigList(config):
+    #Allow for grabbing the era from the config file name instead. Only does so if era argument is not given.
+    if args.era == 0:
+      if "2016" in config:
+        temp_era = 2016
+      elif "2017" in config:
+        temp_era = 2017
+      elif "2018" in config:
+        temp_era = 2018
+      else:
+        raise Exception('No era given and none found in config file name. Please specify an era.')
+    else:
+        temp_era = args.era
+
+    process = defaultdict(dict)
+    #TODO: Split between sample set and sample collection configs
+    lines = open(config).readlines()
+    for line_ in lines:
+        line = line_.strip()
+        if(len(line) <= 0 or line[0] == '#'):
+            continue
+        entry = line.split(",")
+        stripped_entry = [ i.strip() for i in entry]
+        #print(stripped_entry)
+        replaced_outdir = stripped_entry[1].replace("Pre","Post")
+        process[stripped_entry[0]] = {
+            #Note that anything appended with __ will not be passed along. These are for bookkeeping. Furthermore, Outpath is not used if an output directory argument is given.
+            "Filepath__" : "%s/%s" % (stripped_entry[1], stripped_entry[2]),
+            #"Outpath__" : "%s" % (replaced_outdir) + VersionNumber + "/" + stripped_entry[0] + "/",
+            "Outpath__" : "%s" % (stripped_entry[1]) + VersionNumber + "/" + stripped_entry[0] + "/", #since these are preprocessed
+            "isData__" : "Data" in stripped_entry[0],
+            "isFastSim" : "fastsim" in stripped_entry[0], #isFastSim is a toggle in Stop0l_postproc.py, so it should be sent with no value.
+            "era" : temp_era,
+        }
+        if process[stripped_entry[0]]["isData__"]:
+            process[stripped_entry[0]].update( {
+                "dataEra": stripped_entry[0][-1], #Example naming convention: Data_MET_2018_PeriodC. Alternate option: match "Period", take location + 6.
+                "crossSection":  float(stripped_entry[4]) , #storing lumi for data
+                "nEvents":  int(stripped_entry[5]),
+            })
+        else:
+            process[stripped_entry[0]].update( {
+                "crossSection":  float(stripped_entry[4]) * float(stripped_entry[7]),
+                "nEvents":  int(stripped_entry[5]) - int(stripped_entry[6]), # using all event weight
+                "sampleName": stripped_entry[0], #process
+                "totEvents__":  int(stripped_entry[5]) + int(stripped_entry[6]), # using all event weight
+            })
+
+    return process
+
+def Condor_Sub(condor_file):
+    curdir = os.path.abspath(os.path.curdir)
+    os.chdir(os.path.dirname(condor_file))
+    print "To submit condor with " + condor_file
+    os.system("condor_submit " + condor_file)
+    os.chdir(curdir)
+
+def GetNEvent(file):
+    return (file, uproot.numentries(file, TTreeName))
+
+def SplitPro(key, file, lineperfile=20, eventsplit=2**18, TreeName=None):
+    # Default to 20 file per job, or 2**20 ~ 1M event per job
+    # At 26Hz processing time in postv2, 1M event runs ~11 hours
+    splitedfiles = []
+    filelistdir = tempdir + '/' + "FileList"
+    try:
+        os.makedirs(filelistdir)
+    except OSError:
+        pass
+
+    if "/store/" in file:
+        subprocess.call("xrdcp root://cmseos.fnal.gov/%s %s/%s_all.list" % (file, filelistdir, key), shell=True)
+        filename = os.path.abspath( "%s/%s_all.list" % (filelistdir, key))
+    else:
+        filename = os.path.abspath(file)
+
+    filecnt = 0
+    eventcnt  = 0
+    filemap = defaultdict(list)
+    if TreeName is None:
+        print("Need Tree name to get number of entries")
+        return splitedfiles, 0
+
+    f = open(filename, 'r')
+    filelist = [l.strip() for l in f.readlines()]
+    splitbyNevent = False
+    if splitbyNevent:
+        r = None
+        pool = Pool(processes=NProcess)
+        r = pool.map(GetNEvent, filelist)
+        pool.close()
+        filedict = dict(r)
+        for l in filelist:
+            n = filedict[l]
+            eventcnt += n
+            if eventcnt > eventsplit:
+                filecnt += 1
+                eventcnt = n
+            filemap[filecnt].append(l)
+    else:
+        g = izip_longest(fillvalue=None, *([iter(filelist)]*lineperfile))
+        filemap = {i:gg for i, gg in enumerate(g)}
+        filecnt = filemap.keys()[-1]
+
+    for k,v in filemap.items():
+        outf = open("%s/%s.%d.list" % (filelistdir, key, k), 'w')
+        outf.write("\n".join(v))
+        splitedfiles.append(os.path.abspath("%s/%s.%d.list" % (filelistdir, key, k)))
+        outf.close()
+
+    return splitedfiles, filecnt+1
+
+def my_process(args):
+    ## temp dir for submit
+    global tempdir
+    global ProjectName
+    ProjectName = time.strftime('%b%d') + ShortProjectName + VersionNumber
+    if args.era == 0:
+        tempdir = tempdir + os.getlogin() + "/" + ProjectName +  "/"
+    else:
+        tempdir = tempdir + os.getlogin() + "/" + ProjectName + "_" + str(args.era) + "/"
+    try:
+        os.makedirs(tempdir)
+    except OSError:
+        pass
+
+    ### Create Tarball
+    Tarfiles = []
+    NewNpro = {}
+
+    ##Read config file
+    Process = ConfigList(os.path.abspath(args.config))
+    #Process = ConfigList(os.path.abspath(args.config), args.era)
+    for key, sample in Process.items():
+        print("Getting process: " + key + " " + sample['Filepath__'])
+        npro, nque = SplitPro(key, sample['Filepath__'], TreeName=TTreeName)
+        Tarfiles+= npro
+        NewNpro[key] = nque
+
+    Tarfiles.append(os.path.abspath(DelExe))
+    tarballname ="%s/%s.tar.gz" % (tempdir, ProjectName)
+    with tarfile.open(tarballname, "w:gz", dereference=True) as tar:
+        [tar.add(f, arcname=f.split('/')[-1]) for f in Tarfiles]
+        tar.close()
+    tarballname += " , %s, " % tar_cmssw()
+    tarballname += " , ".join([os.path.abspath(i) for i in sendfiles])
+
+    ### Update condor and RunExe files
+    for name, sample in Process.items():
+
+        #define output directory
+        if args.outputdir == "": outdir = sample["Outpath__"]
+        else: outdir = args.outputdir + "/" + name + "/"
+
+        #Update RunExe.csh
+        RunHTFile = tempdir + "/" + name + "_RunExe.csh"
+        with open(RunHTFile, "wt") as outfile:
+            # for line in open("RunExe_splitHEM.csh","r"):
+            for line in open("RunExe_fastsim.csh","r"):
+                line = line.replace("DELSCR", os.environ['SCRAM_ARCH'])
+                line = line.replace("DELDIR", os.environ['CMSSW_VERSION'])
+                line = line.replace("DELEXE", DelExe.split('/')[-1])
+                line = line.replace("OUTDIR", outdir)
+                outfile.write(line)
+
+        #Update condor file
+        #First argument is output file name. Rest are to be passed to Stop0l_postproc.py.
+        arg = "\nArguments = _$(Process).root --inputfile={common_name}.$(Process).list ".format(common_name=name)
+        for k, v in sample.items():
+            if "__" in k:
+                continue
+            if k == "isFastSim":
+                if v is True:
+                    arg+=" --%s" % k
+            else:
+                arg+=" --%s=%s" % (k, v)
+        arg += "\nQueue {number} \n".format(number = NewNpro[name])
+
+        ## Prepare the condor file
+        condorfile = tempdir + "/" + "condor_" + ProjectName + "_" + name
+        with open(condorfile, "wt") as outfile:
+            for line in open("condor_fastsim", "r"):
+                line = line.replace("EXECUTABLE", os.path.abspath(RunHTFile))
+                line = line.replace("TARFILES", tarballname)
+                line = line.replace("TEMPDIR", tempdir)
+                line = line.replace("PROJECTNAME", ProjectName)
+                line = line.replace("SAMPLENAME", name)
+                line = line.replace("ARGUMENTS", arg)
+                outfile.write(line)
+
+        Condor_Sub(condorfile)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='NanoAOD postprocessing.')
+    parser.add_argument('-c', '--config',
+        default = "sampleconfig.cfg",
+        help = 'Path to the input config file.')
+    parser.add_argument('-e', '--era',
+        default = "0",type=int,
+        help = 'Era/Year of the config file. Use if this is not part of the config file name. Will also be appended to the condor directory in the user\'s nobackup area if used.')
+    parser.add_argument('-o', '--outputdir',
+        default = "", 
+        help = 'Path to the output directory.')
+
+    args = parser.parse_args()
+    my_process(args)

--- a/python/processors/Condor/condor_fastsim
+++ b/python/processors/Condor/condor_fastsim
@@ -1,0 +1,12 @@
+universe = vanilla
+Executable = EXECUTABLE
+Requirements = (OpSys == "LINUX") && (Arch != "DUMMY" )
+Should_Transfer_Files = YES
+WhenToTransferOutput = ON_EXIT
+Transfer_Input_Files = TARFILES, haddnano.py
+Output = TEMPDIR/PROJECTNAME_SAMPLENAME_$(Cluster)_$(Process).stdout
+Error = TEMPDIR/PROJECTNAME_SAMPLENAME_$(Cluster)_$(Process).stderr
+Log = TEMPDIR/PROJECTNAME_SAMPLENAME_$(Cluster)_$(Process).log
+
+ARGUMENTS
+

--- a/python/processors/Stop0l_fastsim.py
+++ b/python/processors/Stop0l_fastsim.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+import os, sys
+import argparse
+import ROOT
+import time
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+
+from PhysicsTools.NanoAODTools.postprocessing.framework.postprocessor import PostProcessor
+from PhysicsTools.NanoAODTools.postprocessing.modules.common.puWeightProducer import *
+from PhysicsTools.NanoAODTools.postprocessing.modules.jme.jecUncertainties import jecUncertProducer
+from PhysicsTools.NanoAODTools.postprocessing.modules.jme.jetmetUncertainties import jetmetUncertaintiesProducer
+from PhysicsTools.NanoAODTools.postprocessing.modules.jme.jetRecalib import jetRecalib
+from PhysicsTools.NanoAODTools.postprocessing.modules.btv.btagSFProducer import btagSFProducer
+from TopTagger.TopTagger.TopTaggerProducer import TopTaggerProducer
+
+# NanoSUSY Tools modules
+from PhysicsTools.NanoSUSYTools.modules.eleMiniCutIDProducer import *
+from PhysicsTools.NanoSUSYTools.modules.Stop0lObjectsProducer import *
+from PhysicsTools.NanoSUSYTools.modules.Stop0lBaselineProducer import *
+from PhysicsTools.NanoSUSYTools.modules.DeepTopProducer import *
+from PhysicsTools.NanoSUSYTools.modules.updateEvtWeight import *
+from PhysicsTools.NanoSUSYTools.modules.lepSFProducer import *
+from PhysicsTools.NanoSUSYTools.modules.updateJetIDProducer import UpdateJetID
+from PhysicsTools.NanoSUSYTools.modules.PDFUncertaintyProducer import PDFUncertiantyProducer
+from PhysicsTools.NanoSUSYTools.modules.GenPartFilter import GenPartFilter
+from PhysicsTools.NanoSUSYTools.modules.BtagSFWeightProducer import BtagSFWeightProducer
+from PhysicsTools.NanoSUSYTools.modules.UpdateMETProducer import UpdateMETProducer
+from PhysicsTools.NanoSUSYTools.modules.FastsimMassesProducer import FastsimMassesProducer
+from PhysicsTools.NanoSUSYTools.modules.PrefireCorr import PrefCorr
+from PhysicsTools.NanoSUSYTools.modules.ISRWeightProducer import ISRSFWeightProducer
+from PhysicsTools.NanoSUSYTools.modules.Stop0l_trigger import Stop0l_trigger
+import uproot
+# JEC files are those recomended here (as of Mar 1, 2019)
+# https://twiki.cern.ch/twiki/bin/view/CMS/JECDataMC#Recommended_for_MC
+# Actual text files are found here
+# JEC: https://github.com/cms-jet/JECDatabase/tree/master/textFiles
+# JER: https://github.com/cms-jet/JRDatabase/tree/master/textFiles
+DataDepInputs = {
+    "MC": {
+        "2016" : {"pileup_Data": "Cert271036_284044_23Sep2016ReReco_Collisions16.root",
+                  "pileup_MC": "pileup_profile_2016.root",
+                  "JERMC": "Summer16_25nsV1_MC",
+                  "JECMC": "Summer16_07Aug2017_V11_MC",
+                  "redoJEC": False,
+                 },
+        "2017" : {"pileup_Data": "Cert294927_306462_EOY2017ReReco_Collisions17.root",
+                  "pileup_MC": "pileup_profile_2017.root",
+                  "JERMC": "Fall17_V3_MC",
+                  "JECMC": "Fall17_17Nov2017_V32_MC",
+                  "redoJEC": False,
+                 },
+        "2018" : {"pileup_Data": "ReReco2018ABC_PromptEraD_Collisions18.root",
+                  "pileup_MC": "pileup_profile_2018.root",
+                  "JERMC": "Autumn18_V1_MC",
+                  "JECMC": "Autumn18_V8_MC",
+                  "redoJEC": True,
+                 }
+    },
+
+    "FASTSIM": {
+        "2016" : {"pileup_Data": "Cert271036_284044_23Sep2016ReReco_Collisions16.root",
+                  "pileup_MC": "pileup_profile_2016.root",
+                  "JERMC": "Summer16_25nsV1_MC",
+                  "JECMC": "Spring16_25nsFastSimV1_MC",
+                  "redoJEC": False,
+                 },
+        "2017" : {"pileup_Data": "Cert294927_306462_EOY2017ReReco_Collisions17.root",
+                  "pileup_MC": "pileup_profile_2017.root",
+                  "JERMC": "Fall17_V3_MC",
+                  "JECMC": "Fall17_FastsimV1_MC",
+                  "redoJEC": True,
+                 },
+        "2018" : {"pileup_Data": "ReReco2018ABC_PromptEraD_Collisions18.root",
+                  "pileup_MC": "pileup_profile_2018.root",
+                  "JERMC": "Autumn18_V1_MC",
+                  "JECMC": "Fall17_FastsimV1_MC",
+                  "redoJEC": True,
+                 }
+    },
+
+    "Data": {
+        "2016B" : { "JEC": "Summer16_07Aug2017BCD_V11_DATA",
+                    "redoJEC": False,
+                   },
+        "2016C" : { "JEC": "Summer16_07Aug2017BCD_V11_DATA",
+                    "redoJEC": False,
+                   },
+        "2016D" : { "JEC": "Summer16_07Aug2017BCD_V11_DATA",
+                    "redoJEC": False,
+                   },
+        "2016E" : { "JEC": "Summer16_07Aug2017EF_V11_DATA",
+                    "redoJEC": False,
+                   },
+        "2016F" : { "JEC": "Summer16_07Aug2017EF_V11_DATA",
+                    "redoJEC": False,
+                   },
+        "2016G" : { "JEC": "Summer16_07Aug2017GH_V11_DATA",
+                    "redoJEC": False,
+                   },
+        "2016H" : { "JEC": "Summer16_07Aug2017GH_V11_DATA",
+                    "redoJEC": False,
+                   },
+
+        "2017B" : { "JEC": "Fall17_17Nov2017B_V32_DATA",
+                    "redoJEC": False,
+                   },
+        "2017C" : { "JEC": "Fall17_17Nov2017C_V32_DATA",
+                    "redoJEC": False,
+                   },
+        "2017D" : { "JEC": "Fall17_17Nov2017DE_V32_DATA",
+                    "redoJEC": False,
+                   },
+        "2017E" : { "JEC": "Fall17_17Nov2017DE_V32_DATA",
+                    "redoJEC": False,
+                   },
+        "2017F" : { "JEC": "Fall17_17Nov2017F_V32_DATA",
+                    "redoJEC": False,
+                   },
+
+        "2018A" : { "JEC": "Autumn18_RunA_V8_DATA",
+                    "redoJEC": True,
+                   },
+        "2018B" : { "JEC": "Autumn18_RunB_V8_DATA",
+                    "redoJEC": True,
+                   },
+        "2018C" : { "JEC": "Autumn18_RunC_V8_DATA",
+                    "redoJEC": True,
+                   },
+        "2018D" : { "JEC": "Autumn18_RunD_V8_DATA",
+                    "redoJEC": True,
+                   },
+            }
+}
+
+DeepResovledDiscCut = 0.6
+
+def main(args):
+    isdata = len(args.dataEra) > 0
+    isfastsim = args.isFastSim
+    isSUSY = args.sampleName.startswith("SMS_")
+
+    if isdata and isfastsim:
+        print "ERROR: It is impossible to have a dataset that is both data and fastsim"
+        exit(0)
+
+    if isdata:
+        dataType="Data"
+        if not args.era + args.dataEra in DataDepInputs[dataType].keys():
+            print "ERROR: Era \"" + args.era + "\" not recognized"
+            exit(0)
+    elif isfastsim:
+        dataType="FASTSIM"
+        if not args.era + args.dataEra in DataDepInputs[dataType].keys():
+            print "ERROR: Era \"" + args.era + "\" not recognized"
+            exit(0)
+    else:
+        dataType = "MC"
+        if not args.era in DataDepInputs[dataType].keys():
+            print "ERROR: Era \"" + args.era + "\" not recognized"
+            exit(0)
+
+    sampleType = args.sampleName.split("_")[1]
+
+    #mods = [FastsimVarProducer(isfastsim)]
+    mods = [FastsimMassesProducer(isfastsim)]
+
+    #============================================================================#
+    #-------------------------     Run PostProcessor     ------------------------#
+    #============================================================================#
+    files = []
+    if len(args.inputfile) > 5 and args.inputfile[0:5] == "file:":
+        #This is just a single test input file
+        files.append(args.inputfile[5:])
+    else:
+        #this is a file list
+        with open(args.inputfile) as f:
+            files = [line.strip() for line in f]
+
+    p=PostProcessor(args.outputfile,files,cut=None, branchsel=None, outputbranchsel=None, modules=mods,provenance=False,maxEvents=args.maxEvents)
+    p.run()
+
+    #g = files
+    g = [f for f in os.listdir(os.curdir) if (os.path.isfile(f) and "Skim" in f)]
+    import uproot
+    import numpy as np
+    uniq = None
+    for array in uproot.iterate(g, "Events", ["Stop0l_MotherMass",
+                                              "Stop0l_LSPMass"],
+                                entrysteps=1000):
+        comp = zip(array["Stop0l_MotherMass"], array["Stop0l_LSPMass"])
+        uniqcomp = np.unique(comp, axis=0)
+        if uniq is None:
+            uniq = uniqcomp
+        else:
+            uniq = np.concatenate((uniq, uniqcomp), axis=0)
+    masspoints =np.unique(uniq, axis=0)
+    print(masspoints)
+
+    for p in masspoints:
+        cutstr = "Stop0l_MotherMass == %d && Stop0l_LSPMass == %d " % (p[0], p[1])
+        poststr = "_Mom%d_LSP%d" % (p[0], p[1])
+        pp=PostProcessor(args.outputfile,g,cut=cutstr, postfix=poststr, provenance=False,maxEvents=args.maxEvents)
+        pp.run()
+        print(p, poststr)
+        os.system("python haddnano.py SMS_{0}_fastsim_Mom{1}_LSP{2}_{3}.root *_Mom{1}_LSP{2}_*.root".format(sampleType,int(p[0]),int(p[1]),time.strftime('%d%H%M%S')))
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='NanoAOD postprocessing.')
+    parser.add_argument('-i', '--inputfile',
+        default = "testing.txt",
+        help = 'Path to the input filelist. To run with a single file instead of a file list prepend the filepath with \"file:\" (Default: testing.txt)')
+    parser.add_argument('-o', '--outputfile',
+                        default="./",
+                        help = 'Path to the output file location. (Default: .)')
+    parser.add_argument('-e', '--era',
+        default = "2017", help = 'Year of production')
+    parser.add_argument('-f', '--isFastSim', action="store_true",  default = False,
+                        help = "Input file is fastsim (Default: false)")
+    parser.add_argument('-d', '--dataEra',    action="store",  type=str, default = "",
+                        help = "Data era (B, C, D, ...).  Using this flag also switches the procesor to data mode. (Default: None, i.e. MC )")
+    parser.add_argument('-s', '--sampleName',    action="store",  type=str, default = "",
+                        help = "Name of MC sample (from sampleSet file) (Default: )")
+    parser.add_argument('-c', '--crossSection',
+                        type=float,
+                        default = 1,
+                        help = 'Cross Section of MC to use for MC x-sec*lumi weight (Default: 1.0)')
+    parser.add_argument('-n', '--nEvents',
+                        type=float,
+                        default = 1,
+                        help = 'Number of events to use for MC x-sec*lumi weight (NOT the number of events to run over) (Default: 1.0)')
+    parser.add_argument('-m', '--maxEvents',
+                        type=int,
+                        default = -1,
+                        help = 'MAximum number of events to process (Default: all events)')
+    args = parser.parse_args()
+    main(args)

--- a/python/processors/Stop0l_fastsim.py
+++ b/python/processors/Stop0l_fastsim.py
@@ -202,7 +202,7 @@ def main(args):
         pp=PostProcessor(args.outputfile,g,cut=cutstr, postfix=poststr, provenance=False,maxEvents=args.maxEvents)
         pp.run()
         print(p, poststr)
-        os.system("python haddnano.py SMS_{0}_fastsim_Mom{1}_LSP{2}_{3}.root *_Mom{1}_LSP{2}_*.root".format(sampleType,int(p[0]),int(p[1]),time.strftime('%d%H%M%S')))
+        os.system("python haddnano.py SMS_{0}_fastsim_Mom{1}_LSP{2}.root *_Mom{1}_LSP{2}_*.root".format(sampleType,int(p[0]),int(p[1]))
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='NanoAOD postprocessing.')


### PR DESCRIPTION
Stop0l_fastsim.py runs locally with no problems.
A test of the way RunExe_fastsim.csh names the output files ran as expected.
Output directories will be named PreProcessed_(date)_fastsimv(#), similar to current postprocessed split fastsim directories.
Number of files per job needs to be determined. It only took a few minutes to run 2 files locally; I think memory would be a bigger issue than time.